### PR TITLE
Issue #1: View aquifer details by location (Enhancement)

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -5,60 +5,90 @@
         <h1>Province of British Columbia</h1>
       </b-col>
     </b-row>
-    <b-row>
-      <b-col id="selectLocationContainer" cols="3">
+    <b-row class="d-flex align-items-center">
+      <b-col id="selectLocationContainer" cols="4">
         <label for="selectLocation">Select aquifer location:</label>
-        <b-form-select id="selectLocation" v-model="selectedLocation" :options="aquiferLocations"></b-form-select>
+        <b-form-select
+          id="selectLocation"
+          v-model="selectedLocation"
+          :options="aquiferLocations"
+          v-on:change="locationChangeHandler"
+        ></b-form-select>
       </b-col>
-      <b-col id="selectedLocationContainer">
-        Selected location:<br/>
-        <b-alert show><strong>{{ selectedLocation }}</strong></b-alert>
+      <b-col
+        id="selectedLocationContainer"
+        v-if="selectedLocation == 'Please select a location'"
+      >
+        Selected location:<br />
+        <b-alert show
+          ><strong>{{ selectedLocation }}</strong></b-alert
+        >
+      </b-col>
+      <b-col id="selectedLocationDetail" v-else>
+        <b-table striped hover :items="items" :fields="fields"></b-table>
       </b-col>
     </b-row>
   </b-container>
 </template>
 
 <script>
-import AQUIFERS from '@/data/aquifers.json'
-const SELECTPLACEHOLDER = 'Please select a location'
+import AQUIFERS from "@/data/aquifers.json";
+const SELECTPLACEHOLDER = "Please select a location";
 
 export default {
-  components: {
-  },
+  components: {},
   data() {
     return {
       selectedLocation: SELECTPLACEHOLDER,
-      aquifers: AQUIFERS.results // TODO: import aquifers from an API
-    }
+      items: [],
+      fields: ["aquifer_id", "mapping_year", "name", "area", "vulnerability"],
+      aquifers: AQUIFERS.results, // TODO: import aquifers from an API
+    };
+  },
+  methods: {
+    locationChangeHandler(eve) {
+      this.items = [];
+      this.items = this.aquifers.filter((x) => x.location == eve);
+    },
   },
   computed: {
-      aquiferLocations () {
-        let locations = this.aquifers
-          // Remove null or whitespace locations (must do before sort)
-          .filter(item => item.location)
-          // Get only locations
-          .map(function(item) { 
-            let x = item.location.trim()
-            return { value: x, text: x }
-          })
-          // Sort alphabetical by location
-          // BUG: lowercase items go to bottom of list
-          .sort(function(a, b) {
-            if (a.value < b.value) { return -1 }
-            if (a.value > b.value) { return 1 }
-            return 0
-          })
-          // Return unique values (must do after sort, refactor if performance issue)
-          .filter(function(el, idx, arr) {
-            return !idx || el.value != arr[idx - 1].value
-          })
-          // Insert item
-          locations.unshift({value: SELECTPLACEHOLDER, text: SELECTPLACEHOLDER, disabled: true })
-        return locations
-      }
-  }
+    aquiferLocations() {
+      let locations = this.aquifers
+        // Remove null or whitespace locations (must do before sort)
+        .filter((item) => item.location)
+        // Get only locations
+        .map(function (item) {
+          let x = item.location.trim();
+          return { value: x, text: x };
+        })
+        // Sort alphabetical by location
+        // BUG: lowercase items go to bottom of list
+        .sort(function (a, b) {
+          if (a.value < b.value) {
+            return -1;
+          }
+          if (a.value > b.value) {
+            return 1;
+          }
+          return 0;
+        })
+        // Return unique values (must do after sort, refactor if performance issue)
+        .filter(function (el, idx, arr) {
+          return !idx || el.value != arr[idx - 1].value;
+        });
+      // Insert item
+      locations.unshift({
+        value: SELECTPLACEHOLDER,
+        text: SELECTPLACEHOLDER,
+        disabled: true,
+      });
+      return locations;
+    },
+  },
 };
 </script>
-
 <style scoped>
+#selectLocation {
+  width: 100%;
+}
 </style>

--- a/tests/unit/home.spec.js
+++ b/tests/unit/home.spec.js
@@ -11,7 +11,7 @@ describe('Home', () => {
     localVue,
     data() {
       return {
-        selectedLocation: 'here',
+        selectedLocation: 'Please select a location',
         aquifers: [
           // A 'Please select' option should be inserted
           { location: 'here' },
@@ -27,10 +27,17 @@ describe('Home', () => {
     }
   })
   it('Check selectedLocation data', () => {
-    expect(wrapper.find('#selectedLocationContainer strong').text()).toMatch('here')
+    expect(wrapper.find('#selectedLocationContainer strong').text()).toMatch('Please select a location')
     expect(wrapper.find('#selectLocation option').exists()).toBeTruthy()
-    // TODO: create a test that simulates a change in selection
   })
+
+  it('Display aquifer details by location', async () => {
+    await wrapper.setData({selectedLocation: 'Nowhere'})
+    expect(wrapper.findAll('option').at(4).text()).toBe('Nowhere')
+    //table to show details of selected location
+    expect(wrapper.find('#selectedLocationDetail table').exists()).toBeTruthy()
+  })
+
   // Begin known failing test
   it('Check alpha order', () => {
     expect(wrapper.findAll('option').at(1).text()).toBe('123 test ave')


### PR DESCRIPTION
Acceptance Criteria
Given I select a location from the drop-down
When a location is selected
Then one or more aquifer details are displayed on the screen in a table

More information
Replace the 'Selected location' alert box with a table displaying the following fields:

aquifer_id | mapping_year | name | area | vulnerability
In most cases, only one aquifer will return. Location: 'Cassidy' should return more than one for example.
